### PR TITLE
Fix camel case

### DIFF
--- a/py_rename/cmd_args.py
+++ b/py_rename/cmd_args.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
-__author__    = "nagracks"
-__date__      = "02-07-2016"
-__license__   = "GPL3"
-__copyright__ = "Copyright © 2016 nagracks"
-__contributors__ = ["kretusmaximus", "astonge"]
 
 from argparse import ArgumentParser
+
+
+__author__ = "nagracks"
+__date__ = "02-07-2016"
+__license__ = "GPL3"
+__copyright__ = "Copyright © 2016 nagracks"
+__contributors__ = ["kretusmaximus", "astonge"]
 
 
 def parse_args():
@@ -22,21 +24,21 @@ def parse_args():
                         version='%(prog)s version 0.1')
     parser.add_argument('-A',
                         '--prefix',
-                        dest = 'prefix',
+                        dest='prefix',
                         metavar='string',
                         action='store',
                         help="prefix filename with prefix string")
     parser.add_argument('-B',
                         '--postfix',
-                        dest = 'postfix',
+                        dest='postfix',
                         metavar='string',
                         action='store',
                         help="postfix filename with postfix string")
-    
+
     # Boolean args #
     parser.add_argument('-n',
                         '--dryrun',
-                        dest = 'dryrun',
+                        dest='dryrun',
                         action='store_true',
                         help="perform a dry run (will no run any actions)")
     parser.add_argument('--lower',
@@ -51,10 +53,10 @@ def parse_args():
                         help="convert to camel case")
     parser.add_argument('-s',
                         '--silent',
-                        dest = 'silent',
+                        dest='silent',
                         action='store_true',
                         help="silence output")
-    
+
     # Positional args #
     parser.add_argument('filename',
                         help="filename")

--- a/py_rename/py_rename.py
+++ b/py_rename/py_rename.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__author__    = "nagracks"
-__date__      = "02-07-2016"
-__license__   = "GPL3"
+import os
+import re
+from cmd_args import parse_args
+
+
+__author__ = "nagracks"
+__date__ = "02-07-2016"
+__license__ = "GPL3"
 __copyright__ = "Copyright © 2016 nagracks"
 __contributors__ = ["kretusmaximus", "astonge"]
 
-import os
-from cmd_args import parse_args
 
 class RenameIt(object):
 
@@ -31,6 +34,7 @@ class RenameIt(object):
         self.silent = silent
         # Are we actually doing anything or just preforming a dryrun?
         self.do_dryrun = dryrun
+
         if self.do_dryrun:
             print("PERFORMING A DRY RUN (NO ACTIONS WILL BE TAKEN)")
 
@@ -43,7 +47,7 @@ class RenameIt(object):
         if not self.silent:
             print(msg)
 
-    def _rename(self, old_name, new_name):
+    def _rename(self, new_name):
         """Generic rename method with error handling
 
         :param old_name: File to rename
@@ -52,16 +56,16 @@ class RenameIt(object):
         :type new_name: str
         :return:
         """
+
         try:
             if not self.do_dryrun:
-                os.rename(old_name, new_name)
-            self._print("renaming: {old} --> {new}".format(old=old_name,
+                os.rename(self.full_name, new_name)
+            self._print("renaming: {old} --> {new}".format(old=self.full_name,
                                                            new=new_name))
         except OSError as e:
             self._print(
-                "Failed to rename {old} --> {new}: {err}".format(old=old_name,
-                                                                 new=new_name,
-                                                                 err=e))
+                "Failed to rename {old} --> {new}: {err}".
+                format(old=self.full_name, new=new_name, err=e))
 
     def prefix_it(self, prefix_str):
         """Prefix filename with prefix string
@@ -70,9 +74,10 @@ class RenameIt(object):
         :returns: None
 
         """
-        old_name = self.full_name
+        old_name = self.filename
         new_name = prefix_str + old_name
-        self._rename(old_name, new_name)
+        new_name += self.extension
+        self._rename(new_name)
 
     def postfix_it(self, postfix_str):
         """Postfix filename with postfix string
@@ -81,18 +86,20 @@ class RenameIt(object):
         :returns: None
 
         """
-        old_name = self.full_name
-        new_name = self.filename + postfix_str
-        self._rename(old_name, new_name)
+        old_name = self.filename
+        new_name = old_name + postfix_str
+        new_name += self.extension
+        self._rename(new_name)
 
     def lower_it(self):
         """Lowercase the filename
         :returns: None
 
         """
-        old_name = self.full_name
+        old_name = self.filename
         new_name = old_name.lower()
-        self._rename(old_name, new_name)
+        new_name += self.extension
+        self._rename(new_name)
 
     def replace_space(self, fill_char='_'):
         """Replace spaces with fill_char
@@ -103,17 +110,19 @@ class RenameIt(object):
         """
         old_name = self.full_name
         new_name = old_name.replace(' ', fill_char)
-        self._rename(old_name, new_name)
+        self._rename(new_name)
 
     def camel_case(self):
         """Convert to camel case
         :returns: None
 
         """
-        old_name = self.full_name
-        new_name = ''.join(word.title() for word in
-                           old_name.lower().split(' ', '_'))
-        self._rename(old_name, new_name)
+
+        old_name = self.filename
+        modified_name = re.findall('[\w]+', old_name.lower())
+        new_name = ''.join([word.title() for word in modified_name])
+        new_name += self.extension
+        self._rename(new_name)
 
 
 def main():

--- a/py_rename/py_rename.py
+++ b/py_rename/py_rename.py
@@ -118,7 +118,7 @@ class RenameIt(object):
 
         """
 
-        old_name = self.filename
+        old_name = self.filename.replace('_', ' ')
         modified_name = re.findall('[\w]+', old_name.lower())
         new_name = ''.join([word.title() for word in modified_name])
         new_name += self.extension


### PR DESCRIPTION
Fixed camel case and rename method. Below are some of the test case which are tested against the code.

```
bash-3.2$ touch middle.py

Prefix Test
bash-3.2$ python py_rename.py middle.py -A start
('renaming: middle.py --> startmiddle.py',)

Postfix Test
bash-3.2$ python py_rename.py startmiddle.py -B endt                                  
('renaming: startmiddle.py --> startmiddleendt.py',)

Camel Case test
bash-3.2$ python py_rename.py startmiddleendt.py --camel-case
('renaming: startmiddleendt.py --> Startmiddleendt.py',)

Lower test
bash-3.2$ python py_rename.py startmiddleendt.py --camel-case
('renaming: startmiddleendt.py --> Startmiddleendt.py',)

Camel Case test
bash-3.2$ python py_rename.py test_test-test\*test.txt --camel-case
('renaming: test_test-test*test.txt --> TestTestTestTest.txt',)
```
